### PR TITLE
Moved root paths case before split() so it's not testing against an array

### DIFF
--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -20,11 +20,11 @@ Map.prototype.urlHelperName = function (path, action) {
         path = path.toString().replace(/[^a-z]+/ig, '/');
     }
 
-    // remove trailing slashes and split to parts
-    path = path.replace(/^\/|\/$/g, '').split('/');
-
     // handle root paths
     if (path === '' || path === '/') return 'root';
+
+    // remove trailing slashes and split to parts
+    path = path.replace(/^\/|\/$/g, '').split('/');
 
     var helperName = [];
     path.forEach(function (token, index, all) {


### PR DESCRIPTION
urlNameHelper('', '') should return 'root' but instead returns '' since the split('/') command returns an array that is then tested against '' and '/'; moving the root test before the split fixes the issue.
