### PR TITLE
Correct behavior of the as parameter

### DIFF
--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -109,14 +109,14 @@ Map.prototype.root = function (handler, middleware, options) {
     };
 });
 
-Map.prototype.addPath = function (templatePath, action, fallbackHelperName) {
+Map.prototype.addPath = function (templatePath, action, helperName) {
     if (templatePath instanceof RegExp) {
         // TODO: think about adding to `path_to` routes by reg ex
         return;
     }
     var paramsLength = templatePath.match(/\/:/g);
     paramsLength = paramsLength === null ? 0 : paramsLength.length;
-    var helperName = this.urlHelperName(templatePath, action) || fallbackHelperName;
+    helperName = helperName || this.urlHelperName(templatePath, action);
 
     // already defined? not need to redefine
     if (this.pathTo[helperName]) return;

--- a/test/railway_routes_test.js
+++ b/test/railway_routes_test.js
@@ -116,10 +116,10 @@ it('should allow overwrite path and helper', function (test) {
         [ 'PUT', '/pictures/:id.:format?', 'avatars#update' ],
         [ 'GET', '/pictures/:id.:format?', 'avatars#show' ]
     ]);
-    test.equal(map.pathTo.pictures, '/pictures');
-    test.equal(map.pathTo.new_picture, '/pictures/new');
-    test.equal(map.pathTo.edit_picture(1), '/pictures/1/edit');
-    test.equal(map.pathTo.picture(1602), '/pictures/1602');
+    test.equal(map.pathTo.images, '/pictures');
+    test.equal(map.pathTo.new_image, '/pictures/new');
+    test.equal(map.pathTo.edit_image(1), '/pictures/1/edit');
+    test.equal(map.pathTo.image(1602), '/pictures/1602');
     test.done();
 });
 
@@ -139,10 +139,13 @@ it('should allow to specify url helper name', function (test) {
     var paths = [];
     var map = new routes.Map(fakeApp(paths), fakeBridge());
     map.get('/p/:id', 'posts#show', {as: 'post'});
+    map.get('/p/:id/edit', 'posts#edit', {as: 'post_edit'});
     test.deepEqual(paths, [
-        [ 'GET', '/p/:id', 'posts#show' ]
+        [ 'GET', '/p/:id', 'posts#show' ],
+        [ 'GET', '/p/:id/edit', 'posts#edit' ]
     ]);
     test.equal(map.pathTo.post(1), '/p/1');
+    test.equal(map.pathTo.post_edit(1), '/p/1/edit');
     test.done();
 });
 


### PR DESCRIPTION
When the as parameter is passed, it should really be used. Fix the test cases as well.
