### PR TITLE
Make sure appendFormat is always

### DIFF
--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -227,13 +227,14 @@ Map.prototype.resources = function (name, params, actions) {
     var self = this;
     // params are optional
     params = params || {};
-    params.appendFormat = ('appendFormat' in params) ? params.appendFormat : true;
 
     // if params arg omitted, second arg may be `actions`
     if (typeof params == 'function') {
         actions = params;
         params = {};
     }
+    
+    params.appendFormat = ('appendFormat' in params) ? params.appendFormat : true;
 
     // If resource uses the path param, it's subroutes should be
     // prefixed by path, not the resource's name


### PR DESCRIPTION
When calling resources(name,actions) (so skipping the params parameter which seems to be supported), appendFormat is not set.
It should be done after the test on params for a function.
