### PR TITLE
Pass options.parentResources to route handler

### DIFF
--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -155,7 +155,7 @@ Map.prototype.root = function (handler, middleware, options) {
             options = {};
         }
 
-        options.parentResources = this.latestResources;
+        options.parentResources = this.latestResources.slice();
 
         var path;
         if (typeof subpath === 'string') {

--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -44,6 +44,7 @@ function Map(app, bridge) {
     this.middlewareStack = [];
     this.camelCaseHelperNames = false;
     this.nestedRoutesOnCollection = false;
+    this.latestResources = [];
 }
 
 function RoutesCollection(origin, prefix) {
@@ -153,6 +154,8 @@ Map.prototype.root = function (handler, middleware, options) {
         if (!options) {
             options = {};
         }
+
+        options.parentResources = this.latestResources;
 
         var path;
         if (typeof subpath === 'string') {
@@ -322,11 +325,13 @@ Map.prototype.resources = function (name, params, actions) {
     if (typeof actions == 'function') {
         var oldResource = this.latestResource;
         this.latestResource = name;
+        this.latestResources.push(name);
         if (params.singleton) {
             this.subroutes(prefix, actions); // singletons don't need to specify an id
         } else {
             this.subroutes(prefix + '/:' + (singularize(name) || name) + '_id', actions);
         }
+        this.latestResources.shift();
         this.latestResource = oldResource;
     }
 


### PR DESCRIPTION
This could probably use some refactoring like replacing this.latestResource completely by this.latestResources which keeps a stack of parent resources instead of only the immediate parent resource. This is useful if you want to have that information for your route handler. In my case, I want my route handler to execute some authorization middlewares depending on how a controller is called. If 'orders' is nested under the resource 'users', I want to run a middleware that loads the user information. However, if the resource is not nested, I don't need that middleware, etc. So in other words, the way resources are stacked is kind of important to me and probably will be useful to others too so I hope you can merge :+1: 
