### PR TITLE
Namespace middleware fix

### DIFF
--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -130,7 +130,9 @@ Map.prototype.root = function (handler, middleware, options) {
             middleware = []
         }
 
-        middleware = middleware.concat(this.middlewareStack)
+        if (middleware instanceof Array) {
+            middleware = middleware.concat(this.middlewareStack)    
+        }
 
         if (!controller && this.latestResource) {
             controller = this.latestResource;
@@ -312,7 +314,9 @@ Map.prototype.resources = function (name, params, actions) {
         params.middleware = []
     }
 
-    params.middleware = params.middleware.concat(this.middlewareStack)
+    if (params.middleware instanceof Array) {
+        params.middleware = params.middleware.concat(this.middlewareStack)
+    }
     
     params.appendFormat = ('appendFormat' in params) ? params.appendFormat : true;
 

--- a/lib/railway_routes.js
+++ b/lib/railway_routes.js
@@ -126,6 +126,12 @@ Map.prototype.root = function (handler, middleware, options) {
             handler = null;
         }
 
+        if (!middleware) {
+            middleware = []
+        }
+
+        middleware = middleware.concat(this.middlewareStack)
+
         if (!controller && this.latestResource) {
             controller = this.latestResource;
         } else if (!controller) {
@@ -301,6 +307,12 @@ Map.prototype.resources = function (name, params, actions) {
         actions = params;
         params = {};
     }
+
+    if (!params.middleware) {
+        params.middleware = []
+    }
+
+    params.middleware = params.middleware.concat(this.middlewareStack)
     
     params.appendFormat = ('appendFormat' in params) ? params.appendFormat : true;
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -254,5 +254,5 @@ test('should clone object with prefix', function() {
     var clone = map.clone('prefix');
     map.pathTo.testUrl().should.equal('/test/url');
     map.pathTo.testUrl().should.equal('/test/url');
-    clone.testUrl().should.equal('/prefix/test/url');
+    clone.testUrl().should.equal('prefix/test/url');
 });


### PR DESCRIPTION
Before, this didn't work:

```
map.namespace 'api', {middleware: mw.requireAdmin}, (api) ->
    api.resources 'users'
    api.resources 'places', (place) ->
      place.get 'children', 'places#showChildren'
      place.collection (places) ->
        places.get 'find', 'places#findByName'
```

Middleware from this needs to be added to params
